### PR TITLE
Fixed issues with offer legacy fields

### DIFF
--- a/config/workspaces/campaigns_offers.schema_cards.json
+++ b/config/workspaces/campaigns_offers.schema_cards.json
@@ -79,6 +79,13 @@
           "pii": false
         },
         {
+          "name": "legacy",
+          "data_type": "jsonb",
+          "nullable": true,
+          "description": "Legacy Hulu/Disney metadata (hulu_bundle_id, disney_offer_id, etc.)",
+          "pii": false
+        },
+        {
           "name": "profile",
           "data_type": "varchar",
           "nullable": false,
@@ -190,6 +197,84 @@
           "path": "$.paymentMethodRequired",
           "data_type": "array",
           "description": "Whether payment method is required"
+        },
+        {
+          "column": "legacy",
+          "path": "$.hulu_bundle_id",
+          "data_type": "string",
+          "description": "Hulu bundle identifier"
+        },
+        {
+          "column": "legacy",
+          "path": "$.hulu_program_id",
+          "data_type": "string",
+          "description": "Hulu program identifier"
+        },
+        {
+          "column": "legacy",
+          "path": "$.hulu_component_id",
+          "data_type": "string",
+          "description": "Hulu component identifier"
+        },
+        {
+          "column": "legacy",
+          "path": "$.hulu_graph_id",
+          "data_type": "string",
+          "description": "Hulu graph identifier"
+        },
+        {
+          "column": "legacy",
+          "path": "$.hulu_identifier",
+          "data_type": "string",
+          "description": "Hulu identifier code (e.g., NOAH)"
+        },
+        {
+          "column": "legacy",
+          "path": "$.hulu_category",
+          "data_type": "string",
+          "description": "Hulu category (e.g., BASE)"
+        },
+        {
+          "column": "legacy",
+          "path": "$.disney_offer_id",
+          "data_type": "string",
+          "description": "Disney offer UUID"
+        },
+        {
+          "column": "legacy",
+          "path": "$.disney_offer_period",
+          "data_type": "string",
+          "description": "Disney offer period (e.g., MONTH)"
+        },
+        {
+          "column": "legacy",
+          "path": "$.disney_original_product_id",
+          "data_type": "string",
+          "description": "Disney original product UUID"
+        },
+        {
+          "column": "legacy",
+          "path": "$.effective_date",
+          "data_type": "timestamp",
+          "description": "Effective date for the legacy data"
+        },
+        {
+          "column": "legacy",
+          "path": "$.namespace",
+          "data_type": "string",
+          "description": "Namespace (e.g., disney, hulu)"
+        },
+        {
+          "column": "legacy",
+          "path": "$.channel_type",
+          "data_type": "string",
+          "description": "Channel type (e.g., D2C)"
+        },
+        {
+          "column": "legacy",
+          "path": "$.offer_status",
+          "data_type": "string",
+          "description": "Offer status in legacy system (e.g., LIVE)"
         }
       ],
       "common_filters": [

--- a/crates/querygpt-core/src/dsl/compile.rs
+++ b/crates/querygpt-core/src/dsl/compile.rs
@@ -156,7 +156,8 @@ fn field_to_sql_expr(
 
     // Priority 2: Check json_paths in schema (source of truth for JSONB attributes)
     // Try both exact match and camelCase conversion (e.g., package_id → packageId)
-    // ALL JSONB fields are stored as arrays, even single-value fields like brand, startDate
+    // Array fields: use -> operator, caller will add ->> 0 or use array operators
+    // Scalar fields: use ->> operator directly for text extraction
     let field_camel = to_camel_case(field);
     for entity in &cards.entities {
         if let Some(alias) = alias_map.get(&entity.name) {
@@ -164,11 +165,16 @@ fn field_to_sql_expr(
                 // Extract field name from $.fieldName
                 let path_field = json_path.path.trim_start_matches("$.");
                 if path_field == field || path_field == field_camel {
-                    // All JSONB attributes are stored as arrays - return base path (-> 'field')
-                    // Callers will add ->> 0 for single-value arrays or use ?| for multi-value
+                    // Use -> for arrays (caller will add ->> 0 or use array operators)
+                    // Use ->> for scalars (direct text extraction)
+                    let operator = if json_path.data_type.to_lowercase() == "array" {
+                        "->"
+                    } else {
+                        "->>"
+                    };
                     return Some(format!(
-                        "{}.{} -> '{}'",
-                        alias, json_path.column, path_field
+                        "{}.{} {} '{}'",
+                        alias, json_path.column, operator, path_field
                     ));
                 }
             }
@@ -180,8 +186,14 @@ fn field_to_sql_expr(
     if !skip_direct_columns.contains(&field) {
         for entity in &cards.entities {
             if let Some(alias) = alias_map.get(&entity.name) {
-                if entity.columns.iter().any(|c| c.name == field) {
-                    return Some(format!("{}.{}", alias, field));
+                if let Some(col) = entity.columns.iter().find(|c| c.name == field) {
+                    // JSONB columns must be cast to text for serialization
+                    // When user asks for "legacy" or "attributes", return the whole JSONB as text
+                    if col.data_type.to_lowercase() == "jsonb" {
+                        return Some(format!("{}.{}::text", alias, field));
+                    } else {
+                        return Some(format!("{}.{}", alias, field));
+                    }
                 }
             }
         }
@@ -337,7 +349,8 @@ pub fn translate_projections(
         .collect()
 }
 
-/// Helper to check if a field is a JSONB field (all JSONB fields are stored as arrays)
+/// Helper to check if a field is a JSONB array field
+/// Returns true only if the field is defined in json_paths with data_type = "array"
 fn is_jsonb_array_field(field: &str, cards: &SchemaCards) -> bool {
     let field_camel = to_camel_case(field);
 
@@ -353,15 +366,17 @@ fn is_jsonb_array_field(field: &str, cards: &SchemaCards) -> bool {
                 || path_field == field_without_prefix
                 || path_field == field_without_prefix_camel
             {
-                // All JSONB attributes are stored as arrays, regardless of data_type
-                return true;
+                // Check if this specific field is defined as an array type
+                // Legacy fields (e.g., hulu_bundle_id) are scalars, not arrays
+                // Attributes fields may be arrays or scalars depending on data_type
+                return json_path.data_type.to_lowercase() == "array";
             }
         }
     }
     false
 }
 
-/// Get the JSONB base path for a field (e.g., "o.attributes -> 'brand'")
+/// Get the JSONB base path for a field (e.g., "o.attributes -> 'brand'" or "oph.legacy ->> 'hulu_bundle_id'")
 fn get_jsonb_base_path(
     field: &str,
     alias_map: &HashMap<String, String>,
@@ -373,9 +388,16 @@ fn get_jsonb_base_path(
             for json_path in &entity.json_paths {
                 let path_field = json_path.path.trim_start_matches("$.");
                 if path_field == field || path_field == field_camel {
+                    // Use -> for arrays (will be used with array operators like @>, ?|)
+                    // Use ->> for scalars (will be used with standard comparison operators)
+                    let operator = if json_path.data_type.to_lowercase() == "array" {
+                        "->"
+                    } else {
+                        "->>"
+                    };
                     return Some(format!(
-                        "{}.{} -> '{}'",
-                        alias, json_path.column, path_field
+                        "{}.{} {} '{}'",
+                        alias, json_path.column, operator, path_field
                     ));
                 }
             }

--- a/crates/querygpt-core/src/planner/prompt_templates.rs
+++ b/crates/querygpt-core/src/planner/prompt_templates.rs
@@ -384,7 +384,9 @@ IMPORTANT: Fix the errors and output only valid JSON. No explanations outside th
     /// Format schema summary for LLM context
     fn format_schema_summary(schema: &SchemaSummary) -> String {
         let mut result = String::from("SCHEMA SUMMARY:\n");
-        result.push_str("⚠️  IMPORTANT: Use field names directly (e.g., 'id', 'name'). DO NOT prefix with table name or alias!\n\n");
+        result.push_str("⚠️  IMPORTANT: Use field names directly (e.g., 'id', 'name'). DO NOT prefix with table name or alias!\n");
+        result.push_str("📝 NOTE: Fields extracted from JSONB columns (e.g., hulu_bundle_id, disney_offer_id) are queryable as top-level fields.\n");
+        result.push_str("    Example: {\"field\": \"hulu_bundle_id\", \"op\": \"eq\", \"value\": \"29\"} NOT {\"field\": \"legacy->>'hulu_bundle_id'\", ...}\n\n");
 
         // Format tables and fields
         for table in &schema.tables {

--- a/crates/querygpt-core/src/planner/schema_summary.rs
+++ b/crates/querygpt-core/src/planner/schema_summary.rs
@@ -132,16 +132,47 @@ impl SchemaSummary {
                 // Convert columns to field summaries
                 // Skip promoted columns that have JSONB equivalents (we'll expose JSONB version instead)
                 let skip_promoted_columns = ["start_date", "end_date", "status", "countries"];
+
+                // Get list of JSONB columns that have json_paths defined
+                // Add warning to discourage direct selection
+                let jsonb_columns_with_paths: std::collections::HashSet<&str> = entity
+                    .json_paths
+                    .iter()
+                    .map(|jp| jp.column.as_str())
+                    .collect();
+
                 let mut fields: Vec<FieldSummary> = entity
                     .columns
                     .iter()
                     .filter(|col| !skip_promoted_columns.contains(&col.name.as_str()))
-                    .map(|col| FieldSummary {
-                        name: col.name.clone(),
-                        field_type: col.data_type.clone(),
-                        nullable: col.nullable,
-                        description: Some(col.description.clone()),
-                        enum_values: None, // Could be enhanced later
+                    .map(|col| {
+                        let mut description = col.description.clone();
+
+                        // Add warning for JSONB columns with json_paths
+                        if jsonb_columns_with_paths.contains(col.name.as_str()) {
+                            let extracted_fields: Vec<String> = entity
+                                .json_paths
+                                .iter()
+                                .filter(|jp| jp.column == col.name)
+                                .map(|jp| jp.path.trim_start_matches("$.").to_string())
+                                .take(8) // Show first 8 fields
+                                .collect();
+
+                            if !extracted_fields.is_empty() {
+                                description = format!(
+                                    "⚠️ DO NOT USE FOR FILTERING. Use extracted fields instead: {}. This raw JSONB column should only be selected if user explicitly asks for the complete raw JSON object.",
+                                    extracted_fields.join(", ")
+                                );
+                            }
+                        }
+
+                        FieldSummary {
+                            name: col.name.clone(),
+                            field_type: col.data_type.clone(),
+                            nullable: col.nullable,
+                            description: Some(description),
+                            enum_values: None,
+                        }
                     })
                     .collect();
 
@@ -149,11 +180,23 @@ impl SchemaSummary {
                 for json_path in &entity.json_paths {
                     // Extract field name from $.fieldName
                     let field_name = json_path.path.trim_start_matches("$.");
+
+                    // Add note about source column for context
+                    let enhanced_description = if json_path.column == "legacy" || json_path.column == "attributes" {
+                        format!(
+                            "{} (extracted from {} JSONB column)",
+                            json_path.description,
+                            json_path.column
+                        )
+                    } else {
+                        json_path.description.clone()
+                    };
+
                     fields.push(FieldSummary {
                         name: field_name.to_string(),
                         field_type: json_path.data_type.clone(),
                         nullable: true, // JSONB fields are always nullable
-                        description: Some(json_path.description.clone()),
+                        description: Some(enhanced_description),
                         enum_values: None,
                     });
                 }

--- a/crates/querygpt-core/tests/snapshots/compile_report_spec__compile_prepaid_apac_export.snap
+++ b/crates/querygpt-core/tests/snapshots/compile_report_spec__compile_prepaid_apac_export.snap
@@ -212,7 +212,7 @@ expression: plan
     },
     {
       "field": "package_id",
-      "expression": "o.attributes -> 'packageId' ->> 0",
+      "expression": "o.attributes ->> 'packageId'",
       "alias": "package_id"
     }
   ],

--- a/crates/querygpt-core/tests/snapshots/pipeline_sql_snapshots__pipeline_sql__prepaid_apac_export.snap
+++ b/crates/querygpt-core/tests/snapshots/pipeline_sql_snapshots__pipeline_sql__prepaid_apac_export.snap
@@ -12,7 +12,7 @@ SELECT p.id,
        o.status,
        o.attributes -> 'countries' AS countries,
        STRING_AGG(DISTINCT opr.product_id, ','),
-       o.attributes -> 'packageId' ->> 0 AS package_id
+       o.attributes ->> 'packageId' AS package_id
 FROM offers_latest o
 
 JOIN campaign_offers co ON o.id = co.offer_id AND o.profile = co.profile
@@ -31,7 +31,7 @@ GROUP BY p.id,
          CASE WHEN o.end_date::date < CURRENT_DATE THEN 'EXPIRED' ELSE o.status END,
          o.status,
          o.attributes -> 'countries',
-         o.attributes -> 'packageId' ->> 0
+         o.attributes ->> 'packageId'
 ORDER BY p.id ASC,
          c.id ASC,
          o.id ASC

--- a/crates/querygpt-core/tests/snapshots/pipeline_sql_snapshots__pipeline_sql__prepaid_apac_export_pagination.snap
+++ b/crates/querygpt-core/tests/snapshots/pipeline_sql_snapshots__pipeline_sql__prepaid_apac_export_pagination.snap
@@ -12,7 +12,7 @@ SELECT p.id,
        o.status,
        o.attributes -> 'countries' AS countries,
        STRING_AGG(DISTINCT opr.product_id, ','),
-       o.attributes -> 'packageId' ->> 0 AS package_id
+       o.attributes ->> 'packageId' AS package_id
 FROM offers_latest o
 
 JOIN campaign_offers co ON o.id = co.offer_id AND o.profile = co.profile
@@ -31,7 +31,7 @@ GROUP BY p.id,
          CASE WHEN o.end_date::date < CURRENT_DATE THEN 'EXPIRED' ELSE o.status END,
          o.status,
          o.attributes -> 'countries',
-         o.attributes -> 'packageId' ->> 0
+         o.attributes ->> 'packageId'
 ORDER BY p.id ASC,
          c.id ASC,
          o.id ASC


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Distinguish between array and scalar JSONB fields using data_type

- Use appropriate PostgreSQL operators (-> for arrays, ->> for scalars)

- Add legacy JSONB column with Hulu/Disney metadata fields

- Cast JSONB columns to text for proper serialization

- Enhance schema documentation with field extraction warnings


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["JSONB Fields"] --> B["Check data_type"]
  B --> C["Array Type"]
  B --> D["Scalar Type"]
  C --> E["Use -> Operator"]
  D --> F["Use ->> Operator"]
  E --> G["Caller adds array operators"]
  F --> H["Direct text extraction"]
  I["Legacy Column"] --> J["Hulu/Disney Metadata"]
  J --> K["Queryable as top-level fields"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>compile.rs</strong><dd><code>Implement array/scalar JSONB operator distinction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/querygpt-core/src/dsl/compile.rs

<ul><li>Distinguish between array and scalar JSONB fields using data_type <br>field<br> <li> Use -> operator for arrays and ->> operator for scalars in SQL <br>generation<br> <li> Cast JSONB columns to text (::text) for proper serialization<br> <li> Update is_jsonb_array_field() to check data_type instead of assuming <br>all are arrays<br> <li> Update get_jsonb_base_path() to use appropriate operators based on <br>field type</ul>


</details>


  </td>
  <td><a href="https://github.com/jeremycod/genie-querygpt/pull/50/files#diff-ad96475de02452c8c6fbd910ead11d0819a40f808b54dee487c922a29dc7f821">+35/-13</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>prompt_templates.rs</strong><dd><code>Add LLM context for JSONB field extraction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/querygpt-core/src/planner/prompt_templates.rs

<ul><li>Add note explaining that JSONB-extracted fields are queryable as <br>top-level fields<br> <li> Provide example showing correct query format for legacy fields<br> <li> Clarify that users should not manually construct JSONB path syntax</ul>


</details>


  </td>
  <td><a href="https://github.com/jeremycod/genie-querygpt/pull/50/files#diff-a563ea1f07640ba73f734d706ca2b4af6f83662584763978fc13bee1a110c4cc">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>schema_summary.rs</strong><dd><code>Enhance schema summary with JSONB extraction guidance</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/querygpt-core/src/planner/schema_summary.rs

<ul><li>Add warnings to JSONB columns discouraging direct selection<br> <li> List extracted fields from JSONB columns in column descriptions<br> <li> Enhance JSONB path field descriptions with source column information<br> <li> Prevent LLM from using raw JSONB columns when extracted fields are <br>available</ul>


</details>


  </td>
  <td><a href="https://github.com/jeremycod/genie-querygpt/pull/50/files#diff-3b9e2b24db1267f2234c09c73f34a752d99451397a7e3c73bc3d7fb2d8a3d8e7">+50/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>campaigns_offers.schema_cards.json</strong><dd><code>Add legacy JSONB column with Hulu/Disney fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config/workspaces/campaigns_offers.schema_cards.json

<ul><li>Add new legacy JSONB column for Hulu/Disney metadata<br> <li> Add 13 json_path entries for legacy column fields (hulu_bundle_id, <br>disney_offer_id, etc.)<br> <li> Define legacy fields as string/timestamp types instead of arrays<br> <li> Provide descriptions for all legacy metadata fields</ul>


</details>


  </td>
  <td><a href="https://github.com/jeremycod/genie-querygpt/pull/50/files#diff-fa6641ec693d6e5f74df1a004d9c40dd164831cc3ca97b7530fac5c59a4fcf01">+85/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

